### PR TITLE
Styling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
-var PQ = module.exports = require('bindings')('addon.node').PQ;
+var PQ = module.exports = require('bindings')('addon.node').PQ,
+    EventEmitter = require('events').EventEmitter,
+    assert = require('assert');
 
-var EventEmitter = require('events').EventEmitter;
-var assert = require('assert');
-
-for(var key in EventEmitter.prototype) {
+for (var key in EventEmitter.prototype) {
   PQ.prototype[key] = EventEmitter.prototype[key];
 }
 
 //SYNC connects to the server
 //throws an exception in the event of a connection error
-PQ.prototype.connectSync = function(paramString) {
-  if(!paramString) {
+PQ.prototype.connectSync = function (paramString) {
+  if (!paramString) {
     paramString = '';
   }
   var connected = this.$connectSync(paramString);
-  if(!connected) {
+  if (!connected) {
     this.finish();
     throw new Error(this.errorMessage());
   }
@@ -22,29 +21,29 @@ PQ.prototype.connectSync = function(paramString) {
 
 //connects async using a background thread
 //calls the callback with an error if there was one
-PQ.prototype.connect = function(paramString, cb) {
-  if(typeof paramString == 'function') {
+PQ.prototype.connect = function (paramString, cb) {
+  if (typeof paramString == 'function') {
     cb = paramString;
     paramString = '';
   }
-  if(!paramString) {
+  if (!paramString) {
     paramString = '';
   }
   assert(cb, 'Must provide a connection callback');
   this.$connect(paramString, cb);
 };
 
-PQ.prototype.errorMessage = function() {
+PQ.prototype.errorMessage = function () {
   return this.$getLastErrorMessage();
 };
 
 //returns an int for the fd of the socket
-PQ.prototype.socket = function() {
+PQ.prototype.socket = function () {
   return this.$socket();
 };
 
 //finishes the connection & closes it
-PQ.prototype.finish = function() {
+PQ.prototype.finish = function () {
   this.$finish();
 };
 
@@ -53,8 +52,8 @@ PQ.prototype.finish = function() {
 //ntuples, getvalue, etc...
 //returns false if there was an error
 //consume additional error details via PQ#errorMessage & friends
-PQ.prototype.exec = function(commandText) {
-  if(!commandText) {
+PQ.prototype.exec = function (commandText) {
+  if (!commandText) {
     commandText = '';
   }
   this.$exec(commandText);
@@ -65,11 +64,11 @@ PQ.prototype.exec = function(commandText) {
 //ntuples, getvalue, etc...
 //returns false if there was an error
 //consume additional error details via PQ#errorMessage & friends
-PQ.prototype.execParams = function(commandText, parameters) {
-  if(!commandText) {
+PQ.prototype.execParams = function (commandText, parameters) {
+  if (!commandText) {
     commandText = '';
   }
-  if(!parameters) {
+  if (!parameters) {
     parameters = [];
   }
   this.$execParams(commandText, parameters);
@@ -80,12 +79,12 @@ PQ.prototype.execParams = function(commandText, parameters) {
 //ntuples, getvalue, etc...
 //returns false if there was an error
 //consume additional error details via PQ#errorMessage & friends
-PQ.prototype.prepare = function(statementName, commandText, nParams) {
+PQ.prototype.prepare = function (statementName, commandText, nParams) {
   assert.equal(arguments.length, 3, 'Must supply 3 arguments');
-  if(!statementName) {
+  if (!statementName) {
     statementName = '';
   }
-  if(!commandText) {
+  if (!commandText) {
     commandText = '';
   }
   nParams = Number(nParams) || 0;
@@ -97,11 +96,11 @@ PQ.prototype.prepare = function(statementName, commandText, nParams) {
 //ntuples, getvalue, etc...
 //returns false if there was an error
 //consume additional error details via PQ#errorMessage & friends
-PQ.prototype.execPrepared = function(statementName, parameters) {
-  if(!statementName) {
+PQ.prototype.execPrepared = function (statementName, parameters) {
+  if (!statementName) {
     statementName = '';
   }
-  if(!parameters) {
+  if (!parameters) {
     parameters = [];
   }
   this.$execPrepared(statementName, parameters);
@@ -109,8 +108,8 @@ PQ.prototype.execPrepared = function(statementName, parameters) {
 
 //send a command to begin executing a query in async mode
 //returns true if sent, or false if there was a send failure
-PQ.prototype.sendQuery = function(commandText) {
-  if(!commandText) {
+PQ.prototype.sendQuery = function (commandText) {
+  if (!commandText) {
     commandText = '';
   }
   return this.$sendQuery(commandText);
@@ -118,11 +117,11 @@ PQ.prototype.sendQuery = function(commandText) {
 
 //send a command to begin executing a query with parameters in async mode
 //returns true if sent, or false if there was a send failure
-PQ.prototype.sendQueryParams = function(commandText, parameters) {
-  if(!commandText) {
+PQ.prototype.sendQueryParams = function (commandText, parameters) {
+  if (!commandText) {
     commandText = '';
   }
-  if(!parameters) {
+  if (!parameters) {
     parameters = [];
   }
   return this.$sendQueryParams(commandText, parameters);
@@ -130,12 +129,12 @@ PQ.prototype.sendQueryParams = function(commandText, parameters) {
 
 //send a command to prepare a named query in async mode
 //returns true if sent, or false if there was a send failure
-PQ.prototype.sendPrepare = function(statementName, commandText, nParams) {
+PQ.prototype.sendPrepare = function (statementName, commandText, nParams) {
   assert.equal(arguments.length, 3, 'Must supply 3 arguments');
-  if(!statementName) {
+  if (!statementName) {
     statementName = '';
   }
-  if(!commandText) {
+  if (!commandText) {
     commandText = '';
   }
   nParams = Number(nParams) || 0;
@@ -144,11 +143,11 @@ PQ.prototype.sendPrepare = function(statementName, commandText, nParams) {
 
 //send a command to execute a named query in async mode
 //returns true if sent, or false if there was a send failure
-PQ.prototype.sendQueryPrepared = function(statementName, parameters) {
-  if(!statementName) {
+PQ.prototype.sendQueryPrepared = function (statementName, parameters) {
+  if (!statementName) {
     statementName = '';
   }
-  if(!parameters) {
+  if (!parameters) {
     parameters = [];
   }
   return this.$sendQueryPrepared(statementName, parameters);
@@ -161,17 +160,17 @@ PQ.prototype.sendQueryPrepared = function(statementName, parameters) {
 //or false if there was no pending result. if there was no pending result
 //the last found result is not overwritten so you can call getResult as many
 //times as you want, and you'll always have the last available result for consumption
-PQ.prototype.getResult = function() {
+PQ.prototype.getResult = function () {
   return this.$getResult();
 };
 
 //returns a text of the enum associated with the result
 //usually just PGRES_COMMAND_OK or PGRES_FATAL_ERROR
-PQ.prototype.resultStatus = function() {
+PQ.prototype.resultStatus = function () {
   return this.$resultStatus();
 };
 
-PQ.prototype.resultErrorMessage = function() {
+PQ.prototype.resultErrorMessage = function () {
   return this.$resultErrorMessage();
 };
 
@@ -179,49 +178,49 @@ PQ.prototype.resultErrorMessage = function() {
 //this is somewhat handled for you within the c/c++ code
 //by never allowing the code to 'leak' a result. still,
 //if you absolutely want to free it yourself, you can use this.
-PQ.prototype.clear = function() {
+PQ.prototype.clear = function () {
   this.$clear();
 };
 
 //returns the number of tuples (rows) in the result set
-PQ.prototype.ntuples = function() {
+PQ.prototype.ntuples = function () {
   return this.$ntuples();
 };
 
 //returns the number of fields (columns) in the result set
-PQ.prototype.nfields = function() {
+PQ.prototype.nfields = function () {
   return this.$nfields();
 };
 
 //returns the name of the field (column) at the given offset
-PQ.prototype.fname = function(offset) {
+PQ.prototype.fname = function (offset) {
   return this.$fname(offset);
 };
 
 //returns the Oid of the type for the given field
-PQ.prototype.ftype = function(offset) {
+PQ.prototype.ftype = function (offset) {
   return this.$ftype(offset);
 };
 
 //returns a text value at the given row/col
 //if the value is null this still returns empty string
 //so you need to use PQ#getisnull to determine
-PQ.prototype.getvalue = function(row, col) {
+PQ.prototype.getvalue = function (row, col) {
   return this.$getvalue(row, col);
 };
 
 //returns true/false if the value is null
-PQ.prototype.getisnull = function(row, col) {
+PQ.prototype.getisnull = function (row, col) {
   return this.$getisnull(row, col);
 };
 
 //returns the status of the command
-PQ.prototype.cmdStatus = function() {
+PQ.prototype.cmdStatus = function () {
   return this.$cmdStatus();
 };
 
 //returns the tuples in the command
-PQ.prototype.cmdTuples = function() {
+PQ.prototype.cmdTuples = function () {
   return this.$cmdTuples();
 };
 
@@ -231,23 +230,23 @@ PQ.prototype.cmdTuples = function() {
 //works except to clear the SELECT() notification you need to call
 //PQ#consumeInput instead of letting node pull the data off the socket
 //http://www.postgresql.org/docs/9.1/static/libpq-async.html
-PQ.prototype.startReader = function() {
+PQ.prototype.startReader = function () {
   this.$startRead();
 };
 
 //suspends the libuv socket 'read ready' listener
-PQ.prototype.stopReader = function() {
+PQ.prototype.stopReader = function () {
   this.$stopRead();
 };
 
-PQ.prototype.writable = function(cb) {
+PQ.prototype.writable = function (cb) {
   this.$startWrite();
   return this.once('writable', cb);
 };
 
 //returns boolean - false indicates an error condition
 //e.g. a failure to consume input
-PQ.prototype.consumeInput = function() {
+PQ.prototype.consumeInput = function () {
   return this.$consumeInput();
 };
 
@@ -255,44 +254,44 @@ PQ.prototype.consumeInput = function() {
 //the process to block waiting on results
 //false indicates PQ#getResult can be called
 //with an assurance of not blocking
-PQ.prototype.isBusy = function() {
+PQ.prototype.isBusy = function () {
   return this.$isBusy();
 };
 
 //toggles the socket blocking on outgoing writes
-PQ.prototype.setNonBlocking = function(truthy) {
+PQ.prototype.setNonBlocking = function (truthy) {
   return this.$setNonBlocking(truthy ? 1 : 0);
 };
 
 //returns true if the connection is non-blocking on writes, otherwise false
 //note: connection is always non-blocking on reads if using the send* methods
-PQ.prototype.isNonBlocking = function() {
+PQ.prototype.isNonBlocking = function () {
   return this.$isNonBlocking();
 };
 
 //returns 1 if socket is not write-ready
 //returns 0 if all data flushed to socket
 //returns -1 if there is an error
-PQ.prototype.flush = function() {
+PQ.prototype.flush = function () {
   return this.$flush();
 };
 
 //escapes a literal and returns the escaped string
 //I'm not 100% sure this doesn't do any I/O...need to check that
-PQ.prototype.escapeLiteral = function(input) {
-  if(!input) return input;
+PQ.prototype.escapeLiteral = function (input) {
+  if (!input) return input;
   return this.$escapeLiteral(input);
 };
 
-PQ.prototype.escapeIdentifier = function(input) {
-  if(!input) return input;
+PQ.prototype.escapeIdentifier = function (input) {
+  if (!input) return input;
   return this.$escapeIdentifier(input);
 };
 
 //Checks for any notifications which may have arrivied
 //and returns them as a javascript object: {relname: 'string', extra: 'string', be_pid: int}
 //if there are no pending notifications this returns undefined
-PQ.prototype.notifies = function() {
+PQ.prototype.notifies = function () {
   return this.$notifies();
 };
 
@@ -300,7 +299,7 @@ PQ.prototype.notifies = function() {
 //returns 1 if the command was sent successfully
 //returns 0 if the command would block (use PQ#writable here if so)
 //returns -1 if there was an error
-PQ.prototype.putCopyData = function(buffer) {
+PQ.prototype.putCopyData = function (buffer) {
   assert(buffer instanceof Buffer);
   return this.$putCopyData(buffer);
 };
@@ -311,8 +310,8 @@ PQ.prototype.putCopyData = function(buffer) {
 //returns 1 if sent succesfully
 //returns 0 if the command would block
 //returns -1 if there was an error
-PQ.prototype.putCopyEnd = function(errorMessage) {
-  if(errorMessage) {
+PQ.prototype.putCopyEnd = function (errorMessage) {
+  if (errorMessage) {
     return this.$putCopyEnd(errorMessage);
   }
   return this.$putCopyEnd();
@@ -325,6 +324,6 @@ PQ.prototype.putCopyEnd = function(errorMessage) {
 //returns 0 if copy is still in process (async only)
 //returns -1 if the copy is done
 //returns -2 if there was an error
-PQ.prototype.getCopyData = function(async) {
+PQ.prototype.getCopyData = function (async) {
   return this.$getCopyData(!!async);
 };

--- a/test/async-connection.js
+++ b/test/async-connection.js
@@ -1,11 +1,11 @@
-var PQ = require('../')
-var assert = require('assert');
+var PQ = require('../'),
+    assert = require('assert');
 
 
-describe('async connection', function() {
-  it('works', function(done) {
+describe('async connection', function () {
+  it('works', function (done) {
     var pq = new PQ();
-    pq.connect(function(err) {
+    pq.connect(function (err) {
       assert.ifError(err);
       pq.exec('SELECT NOW()');
       assert.equal(pq.ntuples(), 1);
@@ -13,13 +13,13 @@ describe('async connection', function() {
     });
   });
 
-  it('works with hard-coded connection parameters', function(done) {
+  it('works with hard-coded connection parameters', function (done) {
     var pq = new PQ();
     pq.connect('host=localhost', done);
   });
 
-  it('returns an error to the callback if connection fails', function(done) {
-    new PQ().connect('host=asldkfjasldkfjalskdfjasdf', function(err) {
+  it('returns an error to the callback if connection fails', function (done) {
+    new PQ().connect('host=asldkfjasldkfjalskdfjasdf', function (err) {
       assert(err, 'should have passed an error');
       done();
     });

--- a/test/async-socket.js
+++ b/test/async-socket.js
@@ -2,12 +2,12 @@ var LibPQ = require('../'),
     helper = require('./helper'),
     assert = require('assert');
 
-var consume = function(pq, cb) {
-  if(!pq.isBusy()) return cb();
+var consume = function (pq, cb) {
+  if (!pq.isBusy()) return cb();
   pq.startReader();
-  var onReadable = function() {
+  var onReadable = function () {
     assert(pq.consumeInput(), pq.errorMessage());
-    if(pq.isBusy()) {
+    if (pq.isBusy()) {
       console.log('consuming a 2nd buffer of input later...');
       return;
     }
@@ -18,17 +18,17 @@ var consume = function(pq, cb) {
   pq.on('readable', onReadable);
 };
 
-describe('async simple query', function() {
+describe('async simple query', function () {
   helper.setupIntegration();
 
-  it('dispatches simple query', function(done) {
+  it('dispatches simple query', function (done) {
     var pq = this.pq;
     assert(this.pq.setNonBlocking(true));
-    this.pq.writable(function() {
+    this.pq.writable(function () {
       var success = pq.sendQuery('SELECT 1');
       assert.strictEqual(pq.flush(), 0, 'Should have flushed all data to socket');
       assert(success, pq.errorMessage());
-      consume(pq, function() {
+      consume(pq, function () {
         assert.ifError(pq.errorMessage());
         assert(pq.getResult());
         assert.strictEqual(pq.getResult(), false);
@@ -39,12 +39,12 @@ describe('async simple query', function() {
     });
   });
 
-  it('dispatches parameterized query', function(done) {
+  it('dispatches parameterized query', function (done) {
     var pq = this.pq;
     var success = pq.sendQueryParams('SELECT $1::text as name', ['Brian']);
     assert(success, pq.errorMessage());
     assert.strictEqual(pq.flush(), 0, 'Should have flushed query text & parameters');
-    consume(pq, function() {
+    consume(pq, function () {
       assert.ifError(pq.errorMessage());
       assert(pq.getResult());
       assert.strictEqual(pq.getResult(), false);
@@ -54,13 +54,13 @@ describe('async simple query', function() {
     });
   });
 
-  it('dispatches named query', function(done) {
+  it('dispatches named query', function (done) {
     var pq = this.pq;
     var statementName = 'async-get-name';
     var success = pq.sendPrepare(statementName, 'SELECT $1::text as name', 1);
     assert(success, pq.errorMessage());
     assert.strictEqual(pq.flush(), 0, 'Should have flushed query text');
-    consume(pq, function() {
+    consume(pq, function () {
       assert.ifError(pq.errorMessage());
 
       //first time there should be a result
@@ -78,7 +78,7 @@ describe('async simple query', function() {
       var success = pq.sendQueryPrepared(statementName, ['Brian']);
       assert(success, pq.errorMessage());
       assert.strictEqual(pq.flush(), 0, 'Should have flushed parameters');
-      consume(pq, function() {
+      consume(pq, function () {
         assert.ifError(pq.errorMessage());
 
         //consume the result of the query execution

--- a/test/copy-in.js
+++ b/test/copy-in.js
@@ -1,15 +1,15 @@
 var helper = require('./helper'),
     assert = require('assert');
 
-describe('COPY IN', function() {
+describe('COPY IN', function () {
   helper.setupIntegration();
 
-  it('check existing data assuptions', function() {
+  it('check existing data assuptions', function () {
     this.pq.exec('SELECT COUNT(*) FROM test_data');
     assert.equal(this.pq.getvalue(0, 0), 3);
   });
 
-  it('copies data in', function() {
+  it('copies data in', function () {
     var success = this.pq.exec('COPY test_data FROM stdin');
     assert.equal(this.pq.resultStatus(), 'PGRES_COPY_IN');
 
@@ -21,13 +21,13 @@ describe('COPY IN', function() {
     res = this.pq.putCopyEnd();
     assert.strictEqual(res, 1);
 
-    while(this.pq.getResult()) {}
+    while (this.pq.getResult()) {}
 
     this.pq.exec('SELECT COUNT(*) FROM test_data');
     assert.equal(this.pq.getvalue(0, 0), 4);
   });
 
-  it('can cancel copy data in', function() {
+  it('can cancel copy data in', function () {
     var success = this.pq.exec('COPY test_data FROM stdin');
     assert.equal(this.pq.resultStatus(), 'PGRES_COPY_IN');
 
@@ -39,9 +39,10 @@ describe('COPY IN', function() {
     res = this.pq.putCopyEnd('cancel!');
     assert.strictEqual(res, 1);
 
-    while(this.pq.getResult()) {}
+    while (this.pq.getResult()) {}
     assert(this.pq.errorMessage());
-    assert(this.pq.errorMessage().indexOf('cancel!') > -1, this.pq.errorMessage() + ' should have contained "cancel!"');
+    assert(this.pq.errorMessage().indexOf('cancel!') > -1, this.pq.errorMessage() +
+      ' should have contained "cancel!"');
 
     this.pq.exec('SELECT COUNT(*) FROM test_data');
     assert.equal(this.pq.getvalue(0, 0), 4);

--- a/test/copy-out.js
+++ b/test/copy-out.js
@@ -1,16 +1,16 @@
 var helper = require('./helper'),
     assert = require('assert');
 
-describe('COPY OUT', function() {
+describe('COPY OUT', function () {
   helper.setupIntegration();
 
-  var getRow = function(pq, expected) {
+  var getRow = function (pq, expected) {
     var result = pq.getCopyData(false);
     assert(result instanceof Buffer, 'Result should be a buffer');
     assert.equal(result.toString('utf8'), expected);
   };
 
-  it('copies data out', function() {
+  it('copies data out', function () {
     this.pq.exec('COPY test_data TO stdin');
     assert.equal(this.pq.resultStatus(), 'PGRES_COPY_OUT');
     getRow(this.pq, 'brian\t32\n');

--- a/test/error-conditions.js
+++ b/test/error-conditions.js
@@ -1,8 +1,8 @@
 var PQ = require('../'),
     assert = require('assert');
 
-describe('without being connected', function() {
-  it('exec fails', function() {
+describe('without being connected', function () {
+  it('exec fails', function () {
     var pq = new PQ();
 
     pq.exec();
@@ -10,7 +10,7 @@ describe('without being connected', function() {
     assert(pq.errorMessage());
   });
 
-  it('fails on async query', function() {
+  it('fails on async query', function () {
     var pq = new PQ();
     var success = pq.sendQuery('blah');
 

--- a/test/escaping.js
+++ b/test/escaping.js
@@ -1,22 +1,22 @@
 var Libpq = require('../'),
     assert = require('assert');
 
-describe('escapeLiteral', function() {
-  it('fails to escape when the server is not connected', function() {
+describe('escapeLiteral', function () {
+  it('fails to escape when the server is not connected', function () {
     var pq = new Libpq();
     var result = pq.escapeLiteral('test');
     assert.strictEqual(result, null);
     assert(pq.errorMessage());
   });
 
-  it('escapes a simple string', function() {
+  it('escapes a simple string', function () {
     var pq = new Libpq();
     pq.connectSync();
     var result = pq.escapeLiteral('bang');
     assert.equal(result, "'bang'");
   });
 
-  it('escapes a bad string', function() {
+  it('escapes a bad string', function () {
     var pq = new Libpq();
     pq.connectSync();
     var result = pq.escapeLiteral("'; TRUNCATE TABLE blah;");
@@ -24,15 +24,15 @@ describe('escapeLiteral', function() {
   });
 });
 
-describe('escapeIdentifier', function() {
-  it('fails when the server is not connected', function() {
+describe('escapeIdentifier', function () {
+  it('fails when the server is not connected', function () {
     var pq = new Libpq();
     var result = pq.escapeIdentifier('test');
     assert.strictEqual(result, null);
     assert(pq.errorMessage());
   });
 
-  it('escapes a simple string', function() {
+  it('escapes a simple string', function () {
     var pq = new Libpq();
     pq.connectSync();
     var result = pq.escapeIdentifier('bang');

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,20 +1,20 @@
 var PQ = require('../');
 
-var createTable = function(pq) {
+var createTable = function (pq) {
   pq.exec('CREATE TEMP TABLE test_data(name text, age int)');
   console.log(pq.resultErrorMessage());
   pq.exec("INSERT INTO test_data(name, age) VALUES ('brian', 32), ('aaron', 30), ('', null);");
 };
 
 module.exports = {
-  setupIntegration: function() {
-    before(function() {
+  setupIntegration: function () {
+    before(function () {
       this.pq = new PQ();
       this.pq.connectSync();
       createTable(this.pq);
     });
 
-    after(function() {
+    after(function () {
       this.pq.finish();
     });
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var Client = require('../');
 
-describe('connecting', function() {
-  it('works', function() {
+describe('connecting', function () {
+  it('works', function () {
     var client = new Client();
     client.connectSync();
   });

--- a/test/multiple-queries.js
+++ b/test/multiple-queries.js
@@ -1,37 +1,37 @@
-var Libpq = require('../');
-var ok = require('okay');
+var Libpq = require('../'),
+    ok = require('okay');
 
 var queryText = "SELECT * FROM generate_series(1, 1000)";
 
-var query = function(pq, cb) {
+var query = function (pq, cb) {
   var sent = pq.sendQuery(queryText);
-  if(!sent) return cb(new Error(pg.errorMessage()));
+  if (!sent) return cb(new Error(pg.errorMessage()));
   console.log('sent query');
 
   //consume any outstanding results
   //while(!pq.isBusy() && pq.getResult()) {
-    //console.log('consumed unused result')
+  //console.log('consumed unused result')
   //}
 
-  var cleanup = function() {
+  var cleanup = function () {
     pq.removeListener('readable', onReadable);
     pq.stopReader();
   };
 
-  var readError = function(message) {
+  var readError = function (message) {
     cleanup();
     return cb(new Error(message || pq.errorMessage));
   };
 
-  var onReadable = function() {
+  var onReadable = function () {
     //read waiting data from the socket
     //e.g. clear the pending 'select'
-    if(!pq.consumeInput()) {
+    if (!pq.consumeInput()) {
       return readError();
     }
     //check if there is still outstanding data
     //if so, wait for it all to come in
-    if(pq.isBusy()) {
+    if (pq.isBusy()) {
       return;
     }
     //load our result object
@@ -39,7 +39,7 @@ var query = function(pq, cb) {
 
     //"read until results return null"
     //or in our case ensure we only have one result
-    if(pq.getResult()) {
+    if (pq.getResult()) {
       return readError('Only one result at a time is accepted');
     }
     cleanup();
@@ -49,19 +49,19 @@ var query = function(pq, cb) {
   pq.startReader();
 };
 
-describe('multiple queries', function() {
+describe('multiple queries', function () {
   var pq = new Libpq();
   pq.connectSync();
 
-  it('first query works', function(done) {
+  it('first query works', function (done) {
     query(pq, done);
   });
 
-  it('second query works', function(done) {
+  it('second query works', function (done) {
     query(pq, done);
   });
 
-  it('third query works', function(done) {
+  it('third query works', function (done) {
     query(pq, done);
   });
 });

--- a/test/non-blocking-controls.js
+++ b/test/non-blocking-controls.js
@@ -1,13 +1,13 @@
 var helper = require('./helper'),
     assert = require('assert');
 
-describe('set & get non blocking', function() {
+describe('set & get non blocking', function () {
   helper.setupIntegration();
-  it('is initially set to false', function() {
+  it('is initially set to false', function () {
     assert.strictEqual(this.pq.isNonBlocking(), false);
   });
 
-  it('can switch back and forth', function() {
+  it('can switch back and forth', function () {
     assert.strictEqual(this.pq.setNonBlocking(true), true);
     assert.strictEqual(this.pq.isNonBlocking(), true);
     assert.strictEqual(this.pq.setNonBlocking(), true);

--- a/test/notification.js
+++ b/test/notification.js
@@ -1,15 +1,15 @@
 var Libpq = require('../'),
     assert = require('assert');
 
-describe('LISTEN/NOTIFY', function() {
-  before(function() {
+describe('LISTEN/NOTIFY', function () {
+  before(function () {
     this.listener = new Libpq();
     this.notifier = new Libpq();
     this.listener.connectSync();
     this.notifier.connectSync();
   });
 
-  it('works', function() {
+  it('works', function () {
     this.notifier.exec("NOTIFY testing, 'My Payload'");
     var notice = this.listener.notifies();
     assert.equal(notice, null);
@@ -25,7 +25,7 @@ describe('LISTEN/NOTIFY', function() {
     assert(notice.be_pid);
   });
 
-  after(function() {
+  after(function () {
     this.listener.finish();
     this.notifier.finish();
   });

--- a/test/result-accessors.js
+++ b/test/result-accessors.js
@@ -1,23 +1,23 @@
 var assert = require('assert'),
     helper = require('./helper');
 
-describe('result accessors', function() {
+describe('result accessors', function () {
   helper.setupIntegration();
 
-  before(function() {
+  before(function () {
     this.pq.exec("INSERT INTO test_data(name, age) VALUES ('bob', 80) RETURNING *");
     assert(!this.pq.errorMessage());
   });
 
-  it('has ntuples', function() {
+  it('has ntuples', function () {
     assert.strictEqual(this.pq.ntuples(), 1);
   });
 
-  it('has cmdStatus', function() {
+  it('has cmdStatus', function () {
     assert.equal(this.pq.cmdStatus(), 'INSERT 0 1');
   });
 
-  it('has command tuples', function() {
+  it('has command tuples', function () {
     assert.strictEqual(this.pq.cmdTuples(), '1');
   });
 });

--- a/test/socket.js
+++ b/test/socket.js
@@ -2,15 +2,15 @@ var LibPQ = require('../'),
     helper = require('./helper'),
     assert = require('assert');
 
-describe('getting socket', function() {
+describe('getting socket', function () {
   helper.setupIntegration();
 
-  it('returns -1 when not connected', function() {
+  it('returns -1 when not connected', function () {
     var pq = new LibPQ();
     assert.equal(pq.socket(), -1);
   });
 
-  it('returns value when connected', function() {
+  it('returns value when connected', function () {
     assert(this.pq.socket() > 0);
   });
 });

--- a/test/sync-integration.js
+++ b/test/sync-integration.js
@@ -2,24 +2,24 @@ var PQ = require('../'),
     assert = require('assert'),
     helper = require('./helper');
 
-describe('low-level query integration tests', function() {
+describe('low-level query integration tests', function () {
 
   helper.setupIntegration();
 
-  describe('exec', function() {
-    before(function() {
+  describe('exec', function () {
+    before(function () {
       this.pq.exec('SELECT * FROM test_data');
     });
 
-    it('has correct tuples', function() {
+    it('has correct tuples', function () {
       assert.strictEqual(this.pq.ntuples(), 3);
     });
 
-    it('has correct field count', function() {
+    it('has correct field count', function () {
       assert.strictEqual(this.pq.nfields(), 2);
     });
 
-    it('has correct rows', function() {
+    it('has correct rows', function () {
       assert.strictEqual(this.pq.getvalue(0, 0), 'brian');
       assert.strictEqual(this.pq.getvalue(1, 1), '30');
       assert.strictEqual(this.pq.getvalue(2, 0), '');

--- a/test/sync-parameters.js
+++ b/test/sync-parameters.js
@@ -1,24 +1,24 @@
 var assert = require('assert'),
     helper = require('./helper');
 
-describe('sync query with parameters', function() {
+describe('sync query with parameters', function () {
   helper.setupIntegration();
 
-  it('works with single string parameter', function() {
+  it('works with single string parameter', function () {
     var queryText = 'SELECT $1::text as name';
     this.pq.execParams(queryText, ['Brian']);
     assert.strictEqual(this.pq.ntuples(), 1);
     assert.strictEqual(this.pq.getvalue(0, 0), 'Brian');
   });
 
-  it('works with a number parameter', function() {
+  it('works with a number parameter', function () {
     var queryText = 'SELECT $1::int as age';
     this.pq.execParams(queryText, [32]);
     assert.strictEqual(this.pq.ntuples(), 1);
     assert.strictEqual(this.pq.getvalue(0, 0), '32');
   });
 
-  it('works with multiple parameters', function() {
+  it('works with multiple parameters', function () {
     var queryText = 'INSERT INTO test_data(name, age) VALUES($1, $2)';
     this.pq.execParams(queryText, ['Barkley', 4]);
     assert.equal(this.pq.resultErrorMessage(), '');

--- a/test/sync-prepare.js
+++ b/test/sync-prepare.js
@@ -1,22 +1,22 @@
 var assert = require('assert'),
     helper = require('./helper');
 
-describe('prepare and execPrepared', function() {
+describe('prepare and execPrepared', function () {
 
   helper.setupIntegration();
 
   var statementName = 'get-name';
 
-  describe('preparing a statement', function() {
-    it('works properly', function() {
+  describe('preparing a statement', function () {
+    it('works properly', function () {
       this.pq.prepare(statementName, 'SELECT $1::text as name', 1);
       assert.ifError(this.pq.resultErrorMessage());
       assert.equal(this.pq.resultStatus(), 'PGRES_COMMAND_OK');
     });
   });
 
-  describe('executing a prepared statement', function() {
-    it('works properly', function() {
+  describe('executing a prepared statement', function () {
+    it('works properly', function () {
       this.pq.execPrepared(statementName, ['Brian']);
       assert.ifError(this.pq.resultErrorMessage());
       assert.strictEqual(this.pq.ntuples(), 1);

--- a/test/sync.js
+++ b/test/sync.js
@@ -1,60 +1,60 @@
-var PQ = require('../');
+var PQ = require('../'),
     assert = require('assert');
 
-describe('connecting with bad credentials', function() {
-  it('throws an error', function() {
+describe('connecting with bad credentials', function () {
+  it('throws an error', function () {
     try {
       new PQ().connectSync('asldkfjlasdf');
-    } catch(e) {
+    } catch (e) {
       return;
     }
     assert.fail('Should have thrown an exception');
   });
 });
 
-describe('connecting with no credentials', function() {
-  before(function() {
+describe('connecting with no credentials', function () {
+  before(function () {
     this.pq = new PQ();
     this.pq.connectSync();
   });
 
-  after(function() {
+  after(function () {
     this.pq.finish();
   });
 });
 
-describe('result checking', function() {
-  before(function() {
+describe('result checking', function () {
+  before(function () {
     this.pq = new PQ();
     this.pq.connectSync();
   });
 
-  after(function() {
+  after(function () {
     this.pq.finish();
   });
 
-  it('executes query', function() {
+  it('executes query', function () {
     this.pq.exec('SELECT NOW() as my_col');
     assert.equal(this.pq.resultStatus(), 'PGRES_TUPLES_OK');
   });
 
-  it('has 1 tuple', function() {
+  it('has 1 tuple', function () {
     assert.equal(this.pq.ntuples(), 1);
   });
 
-  it('has 1 field', function() {
+  it('has 1 field', function () {
     assert.strictEqual(this.pq.nfields(), 1);
   });
 
-  it('has column name', function() {
+  it('has column name', function () {
     assert.equal(this.pq.fname(0), 'my_col');
   });
 
-  it('has oid type of timestamptz', function() {
+  it('has oid type of timestamptz', function () {
     assert.strictEqual(this.pq.ftype(0), 1184);
   });
 
-  it('has value as a date', function() {
+  it('has value as a date', function () {
     var now = new Date();
     var val = this.pq.getvalue(0);
     var date = new Date(Date.parse(val));
@@ -62,7 +62,7 @@ describe('result checking', function() {
     assert.equal(date.getMonth(), now.getMonth());
   });
 
-  it('can manually clear result multiple times', function() {
+  it('can manually clear result multiple times', function () {
     this.pq.clear();
     this.pq.clear();
     this.pq.clear();


### PR DESCRIPTION
The first commit only adds semicolons and stuff.
In the second commit, I've run JS Beautifier (tabsize 2) over all the JS code. If you don't like its result (consistent use of spaces, mostly, after keywords), tell me, and I will produce a patch without it.

The annoying this of using 2 spaces instead of 4 spaces, is that Beautifier puts 1 tab (=2/4 spaces) in front of the require block elements. It lines up awesomely when using 4 spaces:

``` js
var x = require('x'),
    y = require('y');
```

I do realize you might have your own config of a beautifier, or you TOTALLY hate this. Then I am sorry and I will remove it :P I just see this style a lot in Node.JS.
