### PR TITLE
npm install libpq fail

### DIFF
--- a/src/addon.h
+++ b/src/addon.h
@@ -10,6 +10,10 @@
 #define ESCAPE_SUPPORTED
 #endif
 
+#if PG_VERSION_NUM >= 93000
+#define MORE_ERROR_FIELDS_SUPPORTED
+#endif
+
 #include "connection.h"
 #include "connect-async-worker.h"
 

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -381,7 +381,7 @@ NAN_METHOD(Connection::ResultErrorFields) {
   SET_E(PG_DIAG_INTERNAL_POSITION, "internalPosition");
   SET_E(PG_DIAG_INTERNAL_QUERY, "internalQuery");
   SET_E(PG_DIAG_CONTEXT, "context");
-#ifdef ESCAPE_SUPPORTED
+#ifdef MORE_ERROR_FIELDS_SUPPORTED
   SET_E(PG_DIAG_SCHEMA_NAME, "schemaName");
   SET_E(PG_DIAG_TABLE_NAME, "tableName");
   SET_E(PG_DIAG_COLUMN_NAME, "columnName");


### PR DESCRIPTION
I get the following error when I run `npm install libpq` inside a Debian Wheezy docker container running Node 0.11.14.

```
> libpq@1.3.0 install /var/lib/app/node_modules/libpq
> node-gyp rebuild

child_process: customFds option is deprecated, use stdio instead.
make: Entering directory `/var/lib/app/node_modules/libpq/build'
  CXX(target) Release/obj.target/addon/src/connection.o
../src/connection.cc: In static member function 'static void Connection::ResultErrorFields(const v8::FunctionCallbackInfo<v8::Value>&)':
../src/connection.cc:385:3: error: 'PG_DIAG_SCHEMA_NAME' was not declared in this scope
../src/connection.cc:386:3: error: 'PG_DIAG_TABLE_NAME' was not declared in this scope
../src/connection.cc:387:3: error: 'PG_DIAG_COLUMN_NAME' was not declared in this scope
../src/connection.cc:388:3: error: 'PG_DIAG_DATATYPE_NAME' was not declared in this scope
../src/connection.cc:389:3: error: 'PG_DIAG_CONSTRAINT_NAME' was not declared in this scope
make: *** [Release/obj.target/addon/src/connection.o] Error 1
make: Leaving directory `/var/lib/app/node_modules/libpq/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1059:12)
gyp ERR! System Linux 3.16.4-tinycore64
gyp ERR! command "node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /var/lib/app/node_modules/libpq
gyp ERR! node -v v0.11.14
gyp ERR! node-gyp -v v1.0.2
gyp ERR! not ok 

npm ERR! Linux 3.16.4-tinycore64
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "libpq"
npm ERR! node v0.11.14
npm ERR! npm  v2.0.0
npm ERR! code ELIFECYCLE
npm ERR! libpq@1.3.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the libpq@1.3.0 install script.
npm ERR! This is most likely a problem with the libpq package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls libpq
npm ERR! There is likely additional logging output above.
```

Related, probably, I get the following error when I run `npm install pg-native`:

```
> libpq@1.3.0 install /var/lib/app/node_modules/pg-native/node_modules/libpq
> node-gyp rebuild

child_process: customFds option is deprecated, use stdio instead.
make: Entering directory `/var/lib/app/node_modules/pg-native/node_modules/libpq/build'
  CXX(target) Release/obj.target/addon/src/connection.o
../src/connection.cc: In static member function 'static void Connection::ResultErrorFields(const v8::FunctionCallbackInfo<v8::Value>&)':
../src/connection.cc:385:3: error: 'PG_DIAG_SCHEMA_NAME' was not declared in this scope
../src/connection.cc:386:3: error: 'PG_DIAG_TABLE_NAME' was not declared in this scope
../src/connection.cc:387:3: error: 'PG_DIAG_COLUMN_NAME' was not declared in this scope
../src/connection.cc:388:3: error: 'PG_DIAG_DATATYPE_NAME' was not declared in this scope
../src/connection.cc:389:3: error: 'PG_DIAG_CONSTRAINT_NAME' was not declared in this scope
make: *** [Release/obj.target/addon/src/connection.o] Error 1
make: Leaving directory `/var/lib/app/node_modules/pg-native/node_modules/libpq/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1059:12)
gyp ERR! System Linux 3.16.4-tinycore64
gyp ERR! command "node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /var/lib/app/node_modules/pg-native/node_modules/libpq
gyp ERR! node -v v0.11.14
gyp ERR! node-gyp -v v1.0.2
gyp ERR! not ok 

npm ERR! Linux 3.16.4-tinycore64
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "pg-native"
npm ERR! node v0.11.14
npm ERR! npm  v2.0.0
npm ERR! code ELIFECYCLE
npm ERR! libpq@1.3.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the libpq@1.3.0 install script.
npm ERR! This is most likely a problem with the libpq package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls libpq
npm ERR! There is likely additional logging output above.
```

`libpq-dev` is installed.
