### PR TITLE
Improve sync connection error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,9 @@ PQ.prototype.connectSync = function(paramString) {
   }
   var connected = this.$connectSync(paramString);
   if(!connected) {
+    var err = new Error(this.errorMessage());
     this.finish();
-    throw new Error(this.errorMessage());
+    throw err;
   }
 };
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -6,6 +6,7 @@ describe('connecting with bad credentials', function() {
     try {
       new PQ().connectSync('asldkfjlasdf');
     } catch(e) {
+      assert.equal(e.toString().indexOf('connection pointer is NULL'), -1)
       return;
     }
     assert.fail('Should have thrown an exception');


### PR DESCRIPTION
The connection pointer was being freed before accessing the error. This
resulted in a 'connection pointer is NULL' error message being returned,
making it hard to debug what was actually causing the issue. Now I read the
error message before freeing the connection. :tada:

fixes https://github.com/brianc/node-pg-native/issues/13