### PR TITLE
Update nan version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Brian M. Carlson",
   "license": "MIT",
   "dependencies": {
-    "nan": "1.5.0",
+    "nan": "1.5.3",
     "bindings": "1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey,

I had to update the nan version to 1.5.3 since nan 1.5.0 is broken, when using the version of clang that comes with Xcode 6.3.

Tests seem to run just fine after updating the version.
