### PR TITLE
Update nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Brian M. Carlson",
   "license": "MIT",
   "dependencies": {
-    "nan": "^1.5.0",
+    "nan": "^1.8.4",
     "bindings": "1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
iojs 2.0 needs an up to date nan to work properly

This is needed for [sequelize] (https://github.com/sequelize/sequelize) with pg-native active to work