### PR TITLE
Getting server version from connection object

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,11 @@ PQ.prototype.socket = function() {
   return this.$socket();
 };
 
+// return server version number e.g. 90300
+PQ.prototype.serverVersion = function () {
+  return this.$serverVersion();
+};
+
 //finishes the connection & closes it
 PQ.prototype.finish = function() {
   this.connected = false;

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -14,6 +14,7 @@ NAN_MODULE_INIT(InitAddon) {
   Nan::SetPrototypeMethod(tpl, "$getLastErrorMessage", Connection::GetLastErrorMessage);
   Nan::SetPrototypeMethod(tpl, "$resultErrorFields", Connection::ResultErrorFields);
   Nan::SetPrototypeMethod(tpl, "$socket", Connection::Socket);
+  Nan::SetPrototypeMethod(tpl, "$serverVersion", Connection::ServerVersion);
 
   //sync query functions
   Nan::SetPrototypeMethod(tpl, "$exec", Connection::Exec);

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -78,6 +78,13 @@ NAN_METHOD(Connection::Finish) {
   }
 }
 
+NAN_METHOD(Connection::ServerVersion) {
+  TRACE("Connection::ServerVersion");
+  Connection* self = THIS();
+  info.GetReturnValue().Set(PQserverVersion(self->pq));
+}
+
+
 NAN_METHOD(Connection::Exec) {
   Connection *self = THIS();
   Nan::Utf8String commandText(info[0]);

--- a/src/connection.h
+++ b/src/connection.h
@@ -9,6 +9,7 @@ class Connection : public Nan::ObjectWrap {
     static NAN_METHOD(Create);
     static NAN_METHOD(ConnectSync);
     static NAN_METHOD(Connect);
+    static NAN_METHOD(ServerVersion);
     static NAN_METHOD(Socket);
     static NAN_METHOD(GetLastErrorMessage);
     static NAN_METHOD(Finish);

--- a/test/server-version.js
+++ b/test/server-version.js
@@ -1,0 +1,21 @@
+var Libpq = require('../');
+var assert = require('assert');
+
+describe('Retrieve server version from connection', function() {
+
+  it('return version number when connected', function() {
+    var pq = new Libpq();
+    pq.connectSync();
+    var version = pq.serverVersion();
+    assert.equal(typeof version, 'number');
+    assert(version > 60000);
+  });
+
+  it('return zero when not connected', function() {
+    var pq = new Libpq();
+    var version = pq.serverVersion();
+    assert.equal(typeof version, 'number');
+    assert.equal(version, 0);
+  });
+
+});


### PR DESCRIPTION
I need to know server version to detect if some features are available (e.g. materialized views)

Usage:

```js
pq.serverVersion() //=> 90400
```