### PR TITLE
Use uv_poll_init_socket instead of ..._init

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -669,8 +669,8 @@ bool Connection::ConnectDB(const char* paramString) {
   }
 
   int fd = PQsocket(this->pq);
-  uv_poll_init(uv_default_loop(), &(this->read_watcher), fd);
-  uv_poll_init(uv_default_loop(), &(this->write_watcher), fd);
+  uv_poll_init_socket(uv_default_loop(), &(this->read_watcher), fd);
+  uv_poll_init_socket(uv_default_loop(), &(this->write_watcher), fd);
 
   TRACE("Connection::ConnectSync::Success");
   return true;


### PR DESCRIPTION
This fixes `node-libpq` on Windows for me. (Was encountering #21 through `node-postgres`)
Suggested by the official doc for [uv_poll_t](http://docs.libuv.org/en/v1.x/poll.html#c.uv_poll_init_socket).