### PR TITLE
Fix esacpeLiteral() so it properly returns empty string and null

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,7 +305,7 @@ PQ.prototype.flush = function() {
 //escapes a literal and returns the escaped string
 //I'm not 100% sure this doesn't do any I/O...need to check that
 PQ.prototype.escapeLiteral = function(input) {
-  if(!input) return input;
+  if(input === null) return 'NULL';
   return this.$escapeLiteral(input);
 };
 


### PR DESCRIPTION
escapeLiteral("") should return "''"
and
escapeLiteral(null) should return "NULL"

If empty string is currently sent to escapeLiteral, empty string is returned.  What should be returned is a string containing just an open and close single-quote (which the actual library will do)

If null is sent to the method, the string "NULL" should be returned.