### PR TITLE
Target libc++ instead of libstdc++

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,8 +9,12 @@
       #Default to assuming pg_config is on the PATH.
       'variables': {
         'pgconfig': 'pg_config'
+      },
+      'xcode_settings': {
+          'CLANG_CXX_LIBRARY': 'libc++',
+          'MACOSX_DEPLOYMENT_TARGET': '10.8'
+       }
       }
-     }
     ]
   ],
   'targets': [


### PR DESCRIPTION
libstdc++ has been deprecated, but without specific action, native modules
built with node 6.x or earlier still attempt to link to libstdc++.

(See: https://github.com/nodejs/nan/issues/606)

This can be fixed by explicitly declaring the lib and OS X target in the
binding file.