### PR TITLE
Pass buffers as parameters

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -73,9 +73,8 @@ class Connection : public Nan::ObjectWrap {
     void WriteStop();
     void ClearLastResult();
     void SetLastResult(PGresult* result);
-    static char* NewCString(v8::Local<v8::Value> val);
-    static char** NewCStringArray(v8::Local<v8::Array> jsParams);
     static void DeleteCStringArray(char** array, int length);
+    static void ConvertParameters(v8::Local<v8::Array> jsParams, char** parameters, int* lengths, int* formats);
     void Emit(const char* message);
 };
 


### PR DESCRIPTION
Without this commit, buffers passed as parameters are processed like null-terminated strings.