### PR TITLE
Fixed building against libc++ when osx min target < 10.7

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,17 +5,12 @@
         # Find the pull path to the pg_config command, since iy may not be on the PATH
         'pgconfig': '<!(which pg_config || find /usr/bin /usr/local/bin /usr/pg* /opt -executable -name pg_config -print -quit)'
       }
-     }, {
+    }, {
       #Default to assuming pg_config is on the PATH.
       'variables': {
         'pgconfig': 'pg_config'
       },
-      'xcode_settings': {
-          'CLANG_CXX_LIBRARY': 'libc++',
-          'MACOSX_DEPLOYMENT_TARGET': '10.8'
-       }
-      }
-    ]
+    }]
   ],
   'targets': [
     {
@@ -41,6 +36,12 @@
           }
         }, { # OS!="win"
           'libraries' : ['-lpq -L<!@(<(pgconfig) --libdir)']
+        }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7'
+          }
         }]
       ]
     }


### PR DESCRIPTION
Solves #53 when trying to build against libc++ on `MACOSX_DEPLOYMENT_TARGET < 10.7`.

Older versions of node use by default a `MACOSX_DEPLOYMENT_TARGET` incompatible with libc++. Compare [v4.4.7](https://github.com/nodejs/node/blob/v4.4.7/common.gypi#L303) & [v6.9.5](https://github.com/nodejs/node/blob/v6.9.5/common.gypi#L355).

This commit also moves these conditions into its own section for os x.