### PR TITLE
Pass paramFormats and paramLengths onto libpq

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,13 @@ PQ.prototype.execParams = function(commandText, parameters) {
   if(!parameters) {
     parameters = [];
   }
-  this.$execParams(commandText, parameters);
+  var paramFormats = parameters.map(function(value) {
+    return value instanceof Buffer ? 1 : 0;
+  });
+  var paramLengths = parameters.map(function(value) {
+    return value instanceof Buffer ? value.length : 0;
+  });
+  this.$execParams(commandText, parameters, paramFormats, paramLengths);
 };
 
 //SYNC prepares a named query and stores the result
@@ -123,7 +129,13 @@ PQ.prototype.execPrepared = function(statementName, parameters) {
   if(!parameters) {
     parameters = [];
   }
-  this.$execPrepared(statementName, parameters);
+  var paramFormats = parameters.map(function(value) {
+    return value instanceof Buffer ? 1 : 0;
+  });
+  var paramLengths = parameters.map(function(value) {
+    return value instanceof Buffer ? value.length : 0;
+  });
+  this.$execPrepared(statementName, parameters, paramFormats, paramLengths);
 };
 
 //send a command to begin executing a query in async mode
@@ -144,7 +156,13 @@ PQ.prototype.sendQueryParams = function(commandText, parameters) {
   if(!parameters) {
     parameters = [];
   }
-  return this.$sendQueryParams(commandText, parameters);
+  var paramFormats = parameters.map(function(value) {
+    return value instanceof Buffer ? 1 : 0;
+  });
+  var paramLengths = parameters.map(function(value) {
+    return value instanceof Buffer ? value.length : 0;
+  });
+  return this.$sendQueryParams(commandText, parameters, paramFormats, paramLengths);
 };
 
 //send a command to prepare a named query in async mode
@@ -170,7 +188,13 @@ PQ.prototype.sendQueryPrepared = function(statementName, parameters) {
   if(!parameters) {
     parameters = [];
   }
-  return this.$sendQueryPrepared(statementName, parameters);
+  var paramFormats = parameters.map(function(value) {
+    return value instanceof Buffer ? 1 : 0;
+  });
+  var paramLengths = parameters.map(function(value) {
+    return value instanceof Buffer ? value.length : 0;
+  });
+  return this.$sendQueryPrepared(statementName, parameters, paramFormats, paramLengths);
 };
 
 //'pops' a result out of the buffered

--- a/src/connection.h
+++ b/src/connection.h
@@ -76,6 +76,7 @@ class Connection : public Nan::ObjectWrap {
     static char* NewCString(v8::Local<v8::Value> val);
     static char** NewCStringArray(v8::Local<v8::Array> jsParams);
     static void DeleteCStringArray(char** array, int length);
+    static int* NewCIntArray(v8::Local<v8::Array> jsParams);
     void Emit(const char* message);
 };
 

--- a/test/async-socket.js
+++ b/test/async-socket.js
@@ -54,6 +54,24 @@ describe('async simple query', function() {
     })
   });
 
+  it('dispatches query with binary parameter', function(done) {
+    var pq = this.pq;
+    var string = 'fo\\o';
+    var buffer = Buffer.from(string, 'utf8');
+    var success = pq.sendQueryParams('SELECT $1::bytea as value', [buffer]);
+    assert(success, pq.errorMessage());
+    assert.strictEqual(pq.flush(), 0, 'Should have flushed query text & parameters');
+    consume(pq, function() {
+      assert.ifError(pq.errorMessage());
+      assert(pq.getResult());
+      assert.strictEqual(pq.getResult(), false);
+      assert.strictEqual(pq.ntuples(), 1);
+      var value = helper.parseHexOutput(pq.getvalue(0, 0));
+      assert.equal(value, string);
+      done();
+    })
+  });
+
   it('dispatches named query', function(done) {
     var pq = this.pq;
     var statementName = 'async-get-name';
@@ -85,6 +103,48 @@ describe('async simple query', function() {
         assert(pq.getResult());
         assert.equal(pq.ntuples(), 1);
         assert.equal(pq.getvalue(0, 0), 'Brian');
+
+        //call 'getResult' again to ensure we're finished
+        assert.strictEqual(pq.getResult(), false);
+        done();
+      });
+    });
+  });
+
+  it('dispatches named query with binary parameter', function(done) {
+    var pq = this.pq;
+    var statementName = 'async-get-binary-param';
+    var string = 'fo\\o';
+    var buffer = Buffer.from(string, 'utf8');
+    var success = pq.sendPrepare(statementName, 'SELECT $1::bytea as value', 1);
+    assert(success, pq.errorMessage());
+    assert.strictEqual(pq.flush(), 0, 'Should have flushed query text');
+    consume(pq, function() {
+      assert.ifError(pq.errorMessage());
+
+      //first time there should be a result
+      assert(pq.getResult());
+
+      //call 'getResult' until it returns false indicating
+      //there is no more input to consume
+      assert.strictEqual(pq.getResult(), false);
+
+      //since we only prepared a statement there should be
+      //0 tuples in the result
+      assert.equal(pq.ntuples(), 0);
+
+      //now execute the previously prepared statement
+      var success = pq.sendQueryPrepared(statementName, [buffer]);
+      assert(success, pq.errorMessage());
+      assert.strictEqual(pq.flush(), 0, 'Should have flushed parameters');
+      consume(pq, function() {
+        assert.ifError(pq.errorMessage());
+
+        //consume the result of the query execution
+        assert(pq.getResult());
+        assert.equal(pq.ntuples(), 1);
+        var value = helper.parseHexOutput(pq.getvalue(0, 0));
+        assert.equal(value, string);
 
         //call 'getResult' again to ensure we're finished
         assert.strictEqual(pq.getResult(), false);

--- a/test/helper.js
+++ b/test/helper.js
@@ -17,5 +17,13 @@ module.exports = {
     after(function() {
       this.pq.finish();
     });
+  },
+  parseHexOutput: function(hexx) {
+    var hex = hexx.toString().substring(2); // remove leading \x
+    var str = '';
+    for (var i = 0; i < hex.length; i += 2) {
+      str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+    }
+    return str;
   }
 };

--- a/test/sync-parameters.js
+++ b/test/sync-parameters.js
@@ -23,4 +23,24 @@ describe('sync query with parameters', function() {
     this.pq.execParams(queryText, ['Barkley', 4]);
     assert.equal(this.pq.resultErrorMessage(), '');
   });
+
+  it('works with non-escaped binary parameter', function() {
+    var queryText = 'SELECT $1::bytea as value';
+    var string = 'foo';
+    var buffer = Buffer.from(string, 'utf8');
+    this.pq.execParams(queryText, [buffer]);
+    assert.strictEqual(this.pq.ntuples(), 1);
+    var value = helper.parseHexOutput(this.pq.getvalue(0, 0));
+    assert.strictEqual(value, string);
+  });
+
+  it('works with escaped binary parameter', function() {
+    var queryText = 'SELECT $1::bytea as value';
+    var string = 'fo\\o';
+    var buffer = Buffer.from(string, 'utf8');
+    this.pq.execParams(queryText, [buffer]);
+    assert.strictEqual(this.pq.ntuples(), 1);
+    var value = helper.parseHexOutput(this.pq.getvalue(0, 0));
+    assert.strictEqual(value, string);
+  });
 });

--- a/test/sync-prepare.js
+++ b/test/sync-prepare.js
@@ -25,3 +25,25 @@ describe('prepare and execPrepared', function() {
     });
   });
 });
+
+describe('prepare and execPrepared with binary parameter', function() {
+
+  helper.setupIntegration();
+
+  var statementName = 'get-binary-param';
+
+  it('works properly', function() {
+    this.pq.prepare(statementName, 'SELECT $1::bytea as value', 1);
+    assert.ifError(this.pq.resultErrorMessage());
+    assert.equal(this.pq.resultStatus(), 'PGRES_COMMAND_OK');
+
+    var string = 'fo\\o';
+    var buffer = Buffer.from(string, 'utf8');
+    this.pq.execPrepared(statementName, [buffer]);
+    assert.ifError(this.pq.resultErrorMessage());
+    assert.strictEqual(this.pq.ntuples(), 1)
+    assert.strictEqual(this.pq.nfields(), 1);
+    var value = helper.parseHexOutput(this.pq.getvalue(0, 0));
+    assert.strictEqual(value, string);
+  });
+});


### PR DESCRIPTION
Similar to #52, this passes `paramFormats` and `paramLengths` onto libpq, except the parameters are constructed in JavaScript. Includes more extensive tests.

Would be happy to add the tests onto #52 if that approach is preferred.

The intent is to fix an inconsistency in node-postgres, where non-native bindings pass buffers as [binary parameters](https://github.com/brianc/node-postgres/blob/e087305f316b364bdbd3045f5c5339b80f757174/lib/connection.js#L248-L251), but native bindings (using this library) pass strings. Passing `paramFormats` and `paramLengths` is currently enough to fix this—if these are passed, libpq correctly detects them as binary parameters (see [PostgreSQL fe-exec.c](https://github.com/postgres/postgres/blob/be72b9c378bfe99a3d175c98d36dc150229f4faf/src/interfaces/libpq/fe-exec.c#L1514-L1557)).

Thanks for looking into this!