### PR TITLE
Added ftable and ftablecol functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Retrieve the number of fields (columns) from the result.
 
 Retrieve the name of the field (column) at the given offset. Offset starts at 0.
 
+##### `pq.ftable(fieldNumber:int):int`
+
+Retrieve the `Oid` of the table at the given offset. Offset starts at 0.
+
+##### `pq.ftablenum(fieldNumber:int):int`
+
+Retrieve the column number (within its table) of the field at the given offset. Offset starts at 0. 
+Query-result column numbers start at 0, but table columns have nonzero numbers.
+
 ##### `pq.ftype(fieldNumber:int):int`
 
 Retrieve the `Oid` of the field (column) at the given offset. Offset starts at 0.

--- a/index.js
+++ b/index.js
@@ -221,6 +221,16 @@ PQ.prototype.fname = function(offset) {
   return this.$fname(offset);
 };
 
+//returns the Oid of the table of the field at the given offset
+PQ.prototype.ftable = function(offset) {
+  return this.$ftable(offset);
+};
+
+//returns the column number (within its table) of the field at the given offset
+PQ.prototype.ftablecol = function(offset) {
+  return this.$ftablecol(offset);
+};
+
 //returns the Oid of the type for the given field
 PQ.prototype.ftype = function(offset) {
   return this.$ftype(offset);

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -44,6 +44,8 @@ NAN_MODULE_INIT(InitAddon) {
   Nan::SetPrototypeMethod(tpl, "$ntuples", Connection::Ntuples);
   Nan::SetPrototypeMethod(tpl, "$nfields", Connection::Nfields);
   Nan::SetPrototypeMethod(tpl, "$fname", Connection::Fname);
+  Nan::SetPrototypeMethod(tpl, "$ftable", Connection::Ftable);
+  Nan::SetPrototypeMethod(tpl, "$ftablecol", Connection::Ftablecol);
   Nan::SetPrototypeMethod(tpl, "$ftype", Connection::Ftype);
   Nan::SetPrototypeMethod(tpl, "$getvalue", Connection::Getvalue);
   Nan::SetPrototypeMethod(tpl, "$getisnull", Connection::Getisnull);

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -210,6 +210,28 @@ NAN_METHOD(Connection::Fname) {
   info.GetReturnValue().Set(Nan::New<v8::String>(colName).ToLocalChecked());
 }
 
+NAN_METHOD(Connection::Ftable) {
+  TRACE("Connection::Ftable");
+  Connection *self = NODE_THIS();
+
+  PGresult* res = self->lastResult;
+
+  int table = PQftable(res, info[0]->Int32Value());
+
+  info.GetReturnValue().Set(table);
+}
+
+NAN_METHOD(Connection::Ftablecol) {
+  TRACE("Connection::Ftablecol");
+  Connection *self = NODE_THIS();
+
+  PGresult* res = self->lastResult;
+
+  int tablecol = PQftablecol(res, info[0]->Int32Value());
+
+  info.GetReturnValue().Set(tablecol);
+}
+
 NAN_METHOD(Connection::Ftype) {
   TRACE("Connection::Ftype");
   Connection *self = NODE_THIS();

--- a/src/connection.h
+++ b/src/connection.h
@@ -21,6 +21,8 @@ class Connection : public Nan::ObjectWrap {
     static NAN_METHOD(Ntuples);
     static NAN_METHOD(Nfields);
     static NAN_METHOD(Fname);
+    static NAN_METHOD(Ftable);
+    static NAN_METHOD(Ftablecol);
     static NAN_METHOD(Ftype);
     static NAN_METHOD(Getvalue);
     static NAN_METHOD(Getisnull);

--- a/test/sync-integration.js
+++ b/test/sync-integration.js
@@ -27,5 +27,12 @@ describe('low-level query integration tests', function() {
       assert.strictEqual(this.pq.getvalue(2, 1), '');
       assert.strictEqual(this.pq.getisnull(2, 1), true);
     });
+
+    it('has correct identifiers', function() {
+      assert.notEqual(this.pq.ftable(0), 0);
+      assert.notEqual(this.pq.ftable(1), 0);
+      assert.strictEqual(this.pq.ftablecol(0), 1);
+      assert.strictEqual(this.pq.ftablecol(1), 2);
+    });
   });
 });

--- a/test/sync.js
+++ b/test/sync.js
@@ -56,6 +56,14 @@ describe('result checking', function() {
     assert.equal(this.pq.fname(0), 'my_col');
   });
 
+  it('has table oid zero', function() {
+    assert.strictEqual(this.pq.ftable(0), 0);
+  });
+
+  it('has column number of the query-result', function() {
+    assert.strictEqual(this.pq.ftablecol(0), 0);
+  });
+
   it('has oid type of timestamptz', function() {
     assert.strictEqual(this.pq.ftype(0), 1184);
   });


### PR DESCRIPTION
Hey,

We have recently noticed that query results of the native pg module does not contain the `tableID` or `columnID` of fields. These properties are however included in the result of node-postgres.

This PR adds `ftable(fieldNumber: int): int` and `ftablenum(fieldNumber: int): int` to libpq. If you accept this PR, I could propose a PR for node-pg-native if you would like me to.