### PR TITLE
Ensure linked binary can find libpq shared object

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -35,7 +35,8 @@
             },
           }
         }, { # OS!="win"
-          'libraries' : ['-lpq -L<!@(<(pgconfig) --libdir)']
+          'libraries' : ['-lpq -L<!@(<(pgconfig) --libdir)'],
+          'ldflags' : ['<!@(<(pgconfig) --ldflags)']
         }],
         ['OS=="mac"', {
           'xcode_settings': {


### PR DESCRIPTION
The build process went fine but it couldn't find the libpq library when actually used. Using `pg_config` output for `ldflags` seems to fix it.

```
Error: Shared object "libpq.so.5" not found, required by "addon.node"
    at Object.Module._extensions..node (module.js:682:18)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at bindings (/home/edho-mastodon/mastodon/node_modules/bindings/bindings.js:76:44)
    at Object.<anonymous> (/home/edho-mastodon/mastodon/node_modules/libpq/index.js:1:108)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
/home/edho-mastodon/mastodon/node_modules/bindings/bindings.js:83
        throw e
        ^
```

`pg_config`:
```
BINDIR = /opt/pg-11/bin
DOCDIR = /opt/pg-11/share/doc/postgresql
HTMLDIR = /opt/pg-11/share/doc/postgresql
INCLUDEDIR = /opt/pg-11/include
PKGINCLUDEDIR = /opt/pg-11/include/postgresql
INCLUDEDIR-SERVER = /opt/pg-11/include/postgresql/server
LIBDIR = /opt/pg-11/lib
PKGLIBDIR = /opt/pg-11/lib/postgresql
LOCALEDIR = /opt/pg-11/share/locale
MANDIR = /opt/pg-11/share/man
SHAREDIR = /opt/pg-11/share/postgresql
SYSCONFDIR = /opt/pg-11/etc/postgresql
PGXS = /opt/pg-11/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--prefix=/opt/pg-11' '--with-includes=/usr/local/include' '--with-libraries=/usr/local/lib'
CC = cc
CPPFLAGS = -I/usr/local/include
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument -O2
CFLAGS_SL = -fPIC -DPIC
LDFLAGS = -L/usr/local/lib -Wl,--as-needed -Wl,-R'/opt/pg-11/lib'
LDFLAGS_EX =
LDFLAGS_SL =
LIBS = -lpgcommon -lpgport -lz -lreadline -lcrypt -lm
VERSION = PostgreSQL 11.1
```
```