### PR TITLE
'ws2_32.lib','secur32.lib','crypt32.lib','wsock32.lib','msvcrt.lib'

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -30,7 +30,7 @@
           'msvs_settings': {
             'VCLinkerTool' : {
               'AdditionalLibraryDirectories' : [
-                '<!@(<(pgconfig) --bindir)\\'
+                '<!@(<(pgconfig) --libdir)\\'
               ]
             },
           }

--- a/binding.gyp
+++ b/binding.gyp
@@ -30,7 +30,7 @@
           'msvs_settings': {
             'VCLinkerTool' : {
               'AdditionalLibraryDirectories' : [
-                '<!@(<(pgconfig) --libdir)\\'
+                '<!@(<(pgconfig) --bindir)\\'
               ]
             },
           }

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,7 @@
       ],
       'conditions' : [
         ['OS=="win"', {
-          'libraries' : ['ws2_32.lib','secur32.lib','crypt32.lib','wsock32.lib','msvcrt.lib','libpq.dll'],
+          'libraries' : ['ws2_32.lib','secur32.lib','crypt32.lib','wsock32.lib','msvcrt.lib','libpq.lib'],
           'msvs_settings': {
             'VCLinkerTool' : {
               'AdditionalLibraryDirectories' : [

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,7 @@
       ],
       'conditions' : [
         ['OS=="win"', {
-          'libraries' : ['ws2_32.lib','secur32.lib','crypt32.lib','wsock32.lib','msvcrt.lib','libpq.lib'],
+          'libraries' : ['ws2_32.lib','secur32.lib','crypt32.lib','wsock32.lib','msvcrt.lib','libpq.dll'],
           'msvs_settings': {
             'VCLinkerTool' : {
               'AdditionalLibraryDirectories' : [

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,7 @@
       ],
       'conditions' : [
         ['OS=="win"', {
-          'libraries' : ['libpq.lib'],
+          'libraries' : ['ws2_32.lib','secur32.lib','crypt32.lib','wsock32.lib','msvcrt.lib','libpq.lib'],
           'msvs_settings': {
             'VCLinkerTool' : {
               'AdditionalLibraryDirectories' : [


### PR DESCRIPTION
These library are required when building node-libqp library on windows.