### PR TITLE
Attempt to build w/o vendor libssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,3 @@ node_js:
 
 env:
   - CC=clang CXX=clang++ npm_config_clang=1 PGUSER=postgres PGDATABASE=postgres PGHOST=localhost
-
-before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      if [[ $(node -v) =~ v[1-9][0-9] ]]; then
-        source ./vendor/build.sh;
-      fi
-    fi


### PR DESCRIPTION
I'm going to work on trying to get the build working without [requiring the user to install a new version of libssl](https://github.com/brianc/node-libpq/pull/67).  I'm a bit rusty on this so help is definitely appreciated, and I'm probably gonna thrash here a bit...

[This looks somewhat helpful, though the resolution instructions are cryptic](https://github.com/nodejs/node-gyp/issues/1386)