### PR TITLE
Fix memory leak

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -803,6 +803,7 @@ void Connection::Emit(const char* message) {
   Nan::TryCatch tc;
   Nan::AsyncResource *async_emit_f = new Nan::AsyncResource("libpq:connection:emit");
   async_emit_f->runInAsyncScope(handle(), emit_f, 1, info);
+  delete async_emit_f;
   if(tc.HasCaught()) {
     Nan::FatalException(tc);
   }


### PR DESCRIPTION
I found a memory leak in the latest release.
Tested:
NodeJS v10.18.1, libpq 1.8.8 - No memory leak
NodeJS v10.18.1, libpq 1.8.9 - There is a memory leak
NodeJS v12.16.3, libpq 1.8.9 - There is a memory leak

I consulted the documentation and reference tests (https://github.com/nodejs/nan/blob/2c4ee8a32a299eada3cd6e468bbd0a473bfea96d/test/cpp/weak.cpp#L23
) and tried to fix.

