### PR TITLE
Fix memory leak and rare segfaults

### DIFF
--- a/src/connect-async-worker.cc
+++ b/src/connect-async-worker.cc
@@ -17,3 +17,10 @@ ConnectAsyncWorker::ConnectAsyncWorker(v8::Local<v8::String> paramString, Connec
       SetErrorMessage(conn->ErrorMessage());
     }
   }
+
+  void ConnectAsyncWorker::HandleOKCallback() {
+    Nan::HandleScope scope;
+
+    conn->InitPollSocket();
+    callback->Call(0, NULL, async_resource);
+}

--- a/src/connect-async-worker.h
+++ b/src/connect-async-worker.h
@@ -8,6 +8,7 @@ public:
   ConnectAsyncWorker(v8::Local<v8::String> paramString, Connection* conn, Nan::Callback* callback);
   ~ConnectAsyncWorker();
   void Execute();
+  void HandleOKCallback();
 
 private:
   Connection* conn;

--- a/src/connection.h
+++ b/src/connection.h
@@ -53,15 +53,16 @@ class Connection : public Nan::ObjectWrap {
     static NAN_METHOD(Cancel);
 
     bool ConnectDB(const char* paramString);
+    void InitPollSocket();
     char* ErrorMessage();
     PGconn* pq;
 
   private:
     PGresult* lastResult;
-    uv_poll_t read_watcher;
-    uv_poll_t write_watcher;
+    uv_poll_t poll_watcher;
     bool is_reffed;
     bool is_reading;
+    bool is_success_poll_init;
 
     Connection();
 


### PR DESCRIPTION
At [Voucherify](https://www.voucherify.io) some time ago, we started using `pg-native` and soon noticed a memory leak in our production. We've fixed it and have been successfully using the fix for the last few months.


The memory leak was caused by [an old bug](https://github.com/brianc/node-libpq/commit/b565eba154d4694137412d625092083a7dc137d0) related to commented `self->Unref()`.
Using node-inspector, I've noticed that each connection object, although closed, was bound to the main event loop and never freed - due to missing `Unref()`.

But as the commit message related to previously commented `Unref()` suggested, some rare segfaults came out.
Using `valgrind` and `ASAN` I've been able to more or less track them. 
There could be at least two sources of those crashes. 

Mandatory fixes:

-  `uv_poll_init_socket` now is executed inside the main event loop (`HandleOKCallback()` is safer)
- Based on [libuv docs](http://docs.libuv.org/en/v1.x/poll.html) it's not correct to have multiple active pool handlers for the same socket, so I've changed that as well. I also added missing `uv_close`.

Regarding other changes, I'm not sure if those are necessary - in the end, segfault reproduction was extremely rare  and took a lot of time - and I didn't manage to test fixes without them. But I can confirm they didn't introduce any harm:
- simplifying calling "emit" function
- using `worker->SaveToPersistent()` for a theoretical case where `Connection` could GCed while still establishing connection (like long conn timeout?)


BTW. While working on this, I've also noticed another memory leak, but you already fixed that one 3 days ago - these changes are unrelated to that one.