### PR TITLE
Avoid assertion error from uv_close on executing finish() twice

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -74,6 +74,7 @@ NAN_METHOD(Connection::Finish) {
   self->ReadStop();
   if (self->is_success_poll_init) {
     uv_close((uv_handle_t*) &self->poll_watcher, NULL);
+    self->is_success_poll_init = false;
   }
   self->ClearLastResult();
   PQfinish(self->pq);


### PR DESCRIPTION
This is in response to [failed integration tests](https://github.com/brianc/node-postgres/runs/7978425129?check_suite_focus=true) in `pg` module after recent changes in this module (#87).

Those tests failed due to `client.end()` was triggered two times. It is somehow related to the fact that `drain` event was triggered two times [in here](https://github.com/brianc/node-postgres/blob/master/packages/pg/test/integration/client/prepared-statement-tests.js#L9). Basically changing addition of that listener from `client.on('drain', ...)` to `client.once('drain', ...)`, also solves the problem but I have a feeling that it would hide real issue.

After fix in this PR tests are passing but I'm not convinced if it's a complete solution for those failed tests either. I would say it's just a part of solution to cover unusual case.