### PR TITLE
[FIX] `pg_config --ldflags` non-existant path

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,7 @@
           }
         }, { # OS!="win"
           'libraries' : ['-lpq -L<!@(<(pgconfig) --libdir)'],
-          'ldflags' : ['<!@(<(pgconfig) --ldflags)']
+          'ldflags' : ['<!@(<(pgconfig) --ldflags_sl)']
         }],
         ['OS=="mac"', {
           'xcode_settings': {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libpq",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "Low-level native bindings to PostgreSQL libpq",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
In fedora (36), `pg_config --ldflags` returns a non-existant file, leading to a failed build.

Adapted the command to only include the flags for the [linked libraries](https://www.postgresql.org/docs/10/app-pgconfig.html)

N.B. I also tested building with the flags completely removed which also succeeded. The approach chosen here preserves more of the original intention.

Addressing https://github.com/brianc/node-libpq/issues/85 