### PR TITLE
feat: support node 23

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "1.5.0",
-    "nan": "2.19.0"
+    "nan": "2.22.0"
   },
   "devDependencies": {
     "async": "^2.6.2",


### PR DESCRIPTION
fix  https://github.com/brianc/node-postgres/issues/3332 caused by https://github.com/nodejs/nan/issues/953 solved in nan 2.22.0, support for node 23