### PR TITLE
Node.js 26 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 26.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -30,6 +30,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Override yargs for Node.js 26
+        if: ${{ matrix.node-version == '26.x' }}
+        run: |
+          npm pkg set overrides.yargs=18.0.0
+          npm install
       - run: npm ci
       - run: npm run build --if-present
       - run: PGTESTNOSSL=true PGUSER=postgres PGHOST=localhost PGPASSWORD=postgres PGDATABASE=ci_db_test npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bindings": "1.5.0",
-        "nan": "~2.23.1"
+        "nan": "~2.26.2"
       },
       "devDependencies": {
         "async": "^2.6.2",
@@ -622,9 +622,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.1.tgz",
-      "integrity": "sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "1.5.0",
-    "nan": "~2.23.1"
+    "nan": "~2.26.2"
   },
   "devDependencies": {
     "async": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,10 +346,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@~2.23.1:
-  version "2.23.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.1.tgz#6f86a31dd87e3d1eb77512bf4b9e14c8aded3975"
-  integrity sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==
+nan@~2.26.2:
+  version "2.26.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.26.2.tgz#2e5e25764224c737b9897790b57c3294d4dcee9c"
+  integrity sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fix support for Node.js 26

This PR includes:
- Bumping `nan` to 2.26.2 to support Node.js 26
- Adding Node.js 26 to the test matrix in the CI
- lockfiles are updated accordingly

Note that `yargs@17` (indirectly required by mocha) is incompatible with Node.js 26, so for that version the CI force-installs `yargs@18`. This is done in the CI instead of adding an `overrides` section in `package.json` since `yargs@18` requires Node.js 20.19.0, which is incompatible with some of the Node.js version the CI is run on.

Fixes #132 