### PR TITLE
fix: validate Buffer type in PutCopyData before calling Buffer::Data

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -656,7 +656,7 @@ NAN_METHOD(Connection::PutCopyData) {
 
   Connection* self = NODE_THIS();
 
-  if (!node::Buffer::HasInstance(info[0]) {
+  if (!node::Buffer::HasInstance(info[0])) {
     return Nan::ThrowTypeError("First argument must be a Buffer");
   }
 

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -656,6 +656,10 @@ NAN_METHOD(Connection::PutCopyData) {
 
   Connection* self = NODE_THIS();
 
+  if (!node::Buffer::HasInstance(info[0]) {
+    return Nan::ThrowTypeError("First argument must be a Buffer");
+  }
+
   v8::Local<v8::Object> buffer = info[0].As<v8::Object>();
 
   char* data = node::Buffer::Data(buffer);

--- a/test/copy-in.js
+++ b/test/copy-in.js
@@ -5,7 +5,7 @@ var bufferFrom = require('buffer-from')
 describe('COPY IN', function() {
   helper.setupIntegration();
 
-  it('check existing data assuptions', function() {
+  it('check existing data assumptions', function() {
     this.pq.exec('SELECT COUNT(*) FROM test_data');
     assert.equal(this.pq.getvalue(0, 0), 3);
   });

--- a/test/copy-in.js
+++ b/test/copy-in.js
@@ -45,4 +45,12 @@ describe('COPY IN', function() {
     this.pq.exec('SELECT COUNT(*) FROM test_data');
     assert.equal(this.pq.getvalue(0, 0), 4);
   });
+
+  it('throws TypeError when non-Buffer is passed to putCopyData', function() {
+    assert.throws(function() {
+      this.pq.$putCopyData("not a buffer");
+    }.bind(this), function(err) {
+      return err instanceof TypeError;
+    });
+  });
 });


### PR DESCRIPTION
$putCopyData() can be called directly on the binding instance, bypassing the instanceof check in the JS wrapper. This adds the same validation at the C++ level so unexpected input throws a TypeError instead of aborting.